### PR TITLE
feat: add role to assume

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ This repository contains a github action that authenticates into Vault using an 
 | role-id | ✓ | The secret containing the role Id for the Vault App Role |  |
 | secret-id | ✓ | The secret containing secret Id for the Vault App Role |  |
 | vault-path | ✓ | The path in Vault where the secrets engine generates AWS credentials |  |
-| role-to-assume | ✘ | The role wanting to be assumed in AWS |  |
+| role-to-assume-arn | ✘ | The ARN for the role wanting to be assumed in AWS | `null` |
 | role-duration-seconds | ✘ | The duration in seconds that the role remains active (default: 15 minutes) | `900` |
+| role-skip-session-tagging | ✘ | Skip session tagging during role assumption | `false` |
+
 
 ## Results
 

--- a/action.yml
+++ b/action.yml
@@ -17,13 +17,18 @@ inputs:
   secret-id:
     description: 'The secret containing secret Id for the Vault App Role'
     required: true
-  role-to-assume:
-    description: 'The role wanting to be assumed in AWS'
+  role-to-assume-arn:
+    description: 'The ARN for the role wanting to be assumed in AWS'
     required: false
+    default: null
   role-duration-seconds:
     description: 'The duration in seconds that the role remains active (default: 15 minutes)'
     required: false
     default: 900
+  role-skip-session-tagging:
+    description: 'Skip session tagging during role assumption'
+    required: false
+    default: false
 
 runs:
   using: 'composite'
@@ -74,7 +79,9 @@ runs:
         aws-access-key-id: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ inputs.aws-region }}
-        role-skip-session-tagging: true
+        role-to-assume: ${{ inputs.role-to-assume-arn }}
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
+        role-skip-session-tagging: ${{ inputs.role-skip-session-tagging }}
 
     - run: aws sts get-caller-identity >/dev/null 2>/dev/null
       shell: bash


### PR DESCRIPTION
# Description

This change will allow you to assume a role and will also allow you to change the duration of the role (default 15 minutes). This will also allow role skip session tagging so `sts:TagSession` is allowed. The configure AWS action configures the environment with the access key, secret access key, and AWS region before trying assume a role. If the ARN passed to the `role-to-assume` parameter doesn't start with `arn:aws` then no role will be assumed. [This can be found here](https://github.com/aws-actions/configure-aws-credentials/blob/9aaa1daa91b40ce855e24cd45fb39b2ca18aeaf1/index.js#L47)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (cleanup or template)
- [ ] Documentation (updates README's or comments)
- [x] New feature (non-breaking change which adds functionality)

## Pull Request Checklist

- [x] Does your PR title confirm to the [Angular JS Format](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)?
- [x] Is the Type one of feat, fix, docs, style, refactor, perf, test, chore?
- [x] Have all GitHub Checks passed?