### PR TITLE
fix: move sleep timer to avoid passing a false check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,8 @@ runs:
     - name: Waiting until AWS credentials are valid
       run: |
         echo "Checking if credentials are valid..."
-
         retries=12
+
         while ((retries > 0)); do
           echo "${retries} attempts left..."
           sleep 5
@@ -58,6 +58,7 @@ runs:
         else
           echo "AWS Credentials are valid."
         fi
+
       shell: bash
       env:
         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
# Description

This change will make the await credentials script wait 5 seconds before trying the received creds in a `get-caller-identity` check, and will avoid causing it to pass this check but fail to configure the credentials in the next step in the workflow.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (cleanup or template)
- [ ] Documentation (updates README's or comments)
- [ ] New feature (non-breaking change which adds functionality)

## Pull Request Checklist

- [x] Does your PR title confirm to the [Angular JS Format](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)?
- [x] Is the Type one of feat, fix, docs, style, refactor, perf, test, chore?
- [ ] Have all GitHub Checks passed?