### PR TITLE
docs: fix capitalization of org name in example use

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the following step to your workflow:
 ```
 
     - name: Vault-AWS Authentication
-      uses: homexlabs/vault-aws-auth@v1
+      uses: HomeXLabs/vault-aws-auth@v1
       with:
         aws-region: us-east-2
         vault-address: https://vault.mycompany.com:8200


### PR DESCRIPTION
# Description

This change adds capitalization in the org name in the example use section of the README/marketplace page.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (cleanup or template)
- [x] Documentation (updates README's or comments)
- [ ] New feature (non-breaking change which adds functionality)

## Pull Request Checklist

- [x] Does your PR title confirm to the [Angular JS Format](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)?
- [x] Is the Type one of feat, fix, docs, style, refactor, perf, test, chore?
- [x] Have all GitHub Checks passed?