### PR TITLE
fix: add retry to configure credentials step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,31 +75,35 @@ runs:
       env:
         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-        AWS_SESSION_TOKEN: ""
+        AWS_SESSION_TOKEN: ''
         AWS_REGION: ${{ inputs.aws-region }}
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+    - name: Retry Configure AWS Credentials
+      uses: Wandalen/wretry.action@v1.0.11
       with:
-        aws-access-key-id: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ inputs.aws-region }}
-        role-to-assume: ${{ inputs.role-to-assume-arn }}
-        role-duration-seconds: ${{ inputs.role-duration-seconds }}
-        role-skip-session-tagging: ${{ inputs.role-skip-session-tagging }}
+        action: aws-actions/configure-aws-credentials@v1
+        with: |
+          aws-access-key-id: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ inputs.aws-region }}
+          role-to-assume: ${{ inputs.role-to-assume-arn }}
+          role-duration-seconds: ${{ inputs.role-duration-seconds }}
+          role-skip-session-tagging: ${{ inputs.role-skip-session-tagging }}
+        attempt_limit: 5
+        attempt_delay: 3000
 
     - run: aws sts get-caller-identity >/dev/null 2>/dev/null
       shell: bash
 
 outputs:
   aws-access-key-id:
-    description: "AWS Access Key ID"
+    description: 'AWS Access Key ID'
     value: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
   aws-secret-access-key:
-    description: "AWS Secret Access Key"
+    description: 'AWS Secret Access Key'
     value: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
   aws-region:
-    description: "AWS Region"
+    description: 'AWS Region'
     value: ${{ inputs.aws-region }}
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,7 @@ runs:
           exit 1
         else
           echo "AWS Credentials are valid."
+          sleep 5
         fi
 
       shell: bash
@@ -78,19 +79,15 @@ runs:
         AWS_SESSION_TOKEN: ''
         AWS_REGION: ${{ inputs.aws-region }}
 
-    - name: Retry Configure AWS Credentials
-      uses: Wandalen/wretry.action@v1.0.11
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
       with:
-        action: aws-actions/configure-aws-credentials@v1
-        with: |
-          aws-access-key-id: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ inputs.aws-region }}
-          role-to-assume: ${{ inputs.role-to-assume-arn }}
-          role-duration-seconds: ${{ inputs.role-duration-seconds }}
-          role-skip-session-tagging: ${{ inputs.role-skip-session-tagging }}
-        attempt_limit: 5
-        attempt_delay: 3000
+        aws-access-key-id: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.role-to-assume-arn }}
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
+        role-skip-session-tagging: ${{ inputs.role-skip-session-tagging }}
 
     - run: aws sts get-caller-identity >/dev/null 2>/dev/null
       shell: bash


### PR DESCRIPTION
# Description

Sometimes when GitHub actions tries to assume the role, the policy allowing it to assume other roles has yet to be attached. So when `Configrue AWS Credentials` tries to assume the desired role, it will fail and exit the workflow because the race condition (lack of permissions). This change will simply sleep for 5 seconds to ensure that the permissions are attached, the retry actions we tried had some bugs so we're just using a simple sleep to get the job done

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (cleanup or template)
- [ ] Documentation (updates README's or comments)
- [ ] New feature (non-breaking change which adds functionality)

## Pull Request Checklist

- [X] Does your PR title confirm to the [Angular JS Format](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)?
- [X] Is the Type one of feat, fix, docs, style, refactor, perf, test, chore?
- [x] Have all GitHub Checks passed?